### PR TITLE
Fix dropdown overflow and z-index

### DIFF
--- a/BreakingChange.md
+++ b/BreakingChange.md
@@ -10,7 +10,7 @@ Efter v4-opgraderingen (juni 2025) ændrede Tailwind både navngivningen af fler
 | **A. Renamede blur-utilities** | `backdrop-blur-sm` hedder nu `backdrop-blur-xs`, og “bare” `blur` hedder `blur-sm` ([tailwindcss.com][1]). Ugyldige klasser ryger derfor tilbage til *ingen* blur-radius, og pseudo-elementet fremstår som en solid halvtransparent plade.        | v4-upgrade-guiden     |
 | **B. Nye cascade-lag**         | Tailwind bruger nu native `@layer`/`@utility`; dit globale `.glass-hero::before` ligger i samme lag som de genererede util-klasser og får derfor højere specificitet end før ([tailwindcss.com][2], [tailwindcss.com][1]).                        | Release Notes + Guide |
 | **C. Manglende isolation**     | Elementet med klassen `glass-hero` i navigationen er **relative** og får et pseudo-element med `z-index:-1` . Da selve nav-baren er `fixed z-50` , havner pseudo-elementet i samme stacking-kontekst som helten (`z-20`)  og fylder hele skærmen. | dine egne filer       |
-| **D. Ny z-index-strategi**     | I v4 anbefales CSS-variabler til konstanter (`z-(--z-index-nav)`) og værdierne må *ikke* være i anførselstegn ([github.com][3]). Hvis du stadig bruger gamle `z-[60]` eller citerede variabler, kolliderer de let.                                | GitHub-diskussion     |
+| **D. Ny z-index-strategi**     | I v4 anbefales CSS-variabler til konstanter (`z-[var(--z-index-nav)]`) og værdierne må *ikke* være i anførselstegn ([github.com][3]). Hvis du stadig bruger gamle `z-[60]` eller citerede variabler, kolliderer de let.                                | GitHub-diskussion     |
 
 ---
 
@@ -52,7 +52,7 @@ Gør det samme for eventuelle “bare” `blur`, `shadow`, `rounded` osv., jf. t
 ```diff
 // Navigation.tsx (nav-wrapper)
 - <div className="flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero">
-+ <div className="flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero z-(--z-index-nav)">
++ <div className="flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero z-[var(--z-index-nav)]">
 ```
 
 ### 3.3  Brug CSS-tema-variabler til z-index
@@ -68,7 +68,7 @@ Gør det samme for eventuelle “bare” `blur`, `shadow`, `rounded` osv., jf. t
 ```diff
 // Dropdown container
 - className="absolute top-full left-1/2 ... z-50"
-+ className="absolute top-full left-1/2 ... z-(--z-index-dropdown)"
++ className="absolute top-full left-1/2 ... z-[var(--z-index-dropdown)]"
 ```
 
 ### 3.4  Ekstra (valgfrit) – stram pseudo-elementet

--- a/TAILWIND_V4_FIX_COMPLETE.md
+++ b/TAILWIND_V4_FIX_COMPLETE.md
@@ -43,17 +43,17 @@ Din guide i `BreakingChange.md` var **100% korrekt** i sin diagnosticering af Ta
 **Navigation.tsx:**
 ```tsx
 // Før: className="fixed top-5 left-0 w-full z-50"
-// Efter: className="fixed top-5 left-0 w-full z-(--z-index-nav)"
+// Efter: className="fixed top-5 left-0 w-full z-[var(--z-index-nav)]"
 
 // Dropdown container:
 // Før: className="absolute top-full left-1/2 ... z-50"
-// Efter: className="absolute top-full left-1/2 ... z-(--z-index-dropdown)"
+// Efter: className="absolute top-full left-1/2 ... z-[var(--z-index-dropdown)]"
 ```
 
 **Hero.tsx:**
 ```tsx
 // Før: className="container mx-auto px-4 py-32 relative z-20"
-// Efter: className="container mx-auto px-4 py-32 relative z-(--z-index-hero)"
+// Efter: className="container mx-auto px-4 py-32 relative z-[var(--z-index-hero)]"
 ```
 
 ### 4. **Utility Class Renames** ✅

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -106,7 +106,7 @@ const Navigation: React.FC<NavigationProps> = () => {
 
   return (
     <motion.nav
-      className="fixed top-5 left-0 w-full z-(--z-index-nav) transition-all duration-300"
+      className="fixed top-5 left-0 w-full z-[var(--z-index-nav)] transition-all duration-300"
       style={{ '--navbar-height': '72px' } as React.CSSProperties}
       initial={{ y: -100, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
@@ -115,7 +115,7 @@ const Navigation: React.FC<NavigationProps> = () => {
     >
       <div className="max-w-[1280px] mx-auto flex items-center justify-between">
         {/* Left Navigation Group */}
-        <div className="flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero">
+        <div className="flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero overflow-visible">
           {/* Logo */}
           <motion.div
             className="shrink-0"
@@ -175,7 +175,7 @@ const Navigation: React.FC<NavigationProps> = () => {
                     animate={{ opacity: 1, y: 0, scale: 1 }}
                     exit={{ opacity: 0, y: 10, scale: 0.95 }}
                     transition={{ duration: 0.2 }}
-                    className="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 w-80 glass-hero rounded-2xl overflow-hidden z-(--z-index-dropdown)"
+                    className="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 w-80 glass-hero rounded-2xl overflow-hidden z-[var(--z-index-dropdown)]"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className="p-4">
@@ -230,7 +230,7 @@ const Navigation: React.FC<NavigationProps> = () => {
         </div>
 
         {/* Right Navigation Group */}
-        <div className="hidden lg:flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero">
+        <div className="hidden lg:flex items-center gap-6 px-6 py-2.5 rounded-full glass-hero overflow-visible">
           {/* Language Selector */}
           <div className="flex items-center gap-1 cursor-pointer pr-4 border-r border-white/20">
             <span className="text-sm">🌐</span>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -54,7 +54,7 @@ const Hero = () => {
         </div>
       </div>
 
-      <div className="container mx-auto px-4 py-32 relative z-(--z-index-hero) flex justify-center">
+      <div className="container mx-auto px-4 py-32 relative z-[var(--z-index-hero)] flex justify-center">
         <div className="w-full max-w-4xl text-center glass-hero p-6 pb-20 rounded-xl relative">
           {/* Main Headline */}
           <div className="space-y-6 mb-6">


### PR DESCRIPTION
## Summary
- allow dropdown to overflow navigation container
- use CSS custom properties for z-index utilities
- update docs for new z-index syntax

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855708ab134832ab258268f8231a0d3